### PR TITLE
SIP-97 front end endpoint

### DIFF
--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -21,6 +21,7 @@
     {#if isLoggedin}
       <ul class="menu menu-horizontal px-1">
         <li><a href="/conference">Conference</a></li>
+        <li><a href="/notifications">Notifications</a></li>
         <li><a href="/reviews">Reviews</a></li>
         <li><a href="/submissions">Submissions</a></li>
       </ul>

--- a/src/routes/notifications/+page.svelte
+++ b/src/routes/notifications/+page.svelte
@@ -1,0 +1,202 @@
+<script lang="ts">
+    import { fade } from 'svelte/transition';
+    import { onMount } from 'svelte';
+    import { goto } from '$app/navigation';
+    import { user } from '$stores/userStore';
+  
+    interface Conference {
+      id: number;
+      title: string;
+      description: string;
+      created_at: string;
+      deadline: string;
+      roles: string[];
+    }
+  
+    interface Notification {
+      id: number;
+      sender: string;
+      conference: Conference;
+      status: string;
+    }
+  
+    let notifications: Notification[] = [];
+    let currentPage = 1;
+    let totalPages = 1;
+    let pageSize = 10;
+  
+
+    async function fetchNotifications(page: number = 1) {
+        try {
+            const response = await fetch(`http://localhost:8000/notifications/?page=${page}&page_size=${pageSize}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                user_id: $user?.id, // Supponendo che l'ID utente sia disponibile tramite il tuo store
+            }),
+            });
+
+            if (!response.ok) {
+            throw new Error('Errore nel recupero delle notifiche');
+            }
+
+            const data = await response.json();
+
+            // Aggiorna le notifiche e i dati di paginazione
+            notifications = data.notifications.map((n: any) => ({
+            id: n.id,
+            sender: n.sender,
+            conference: {
+                id: n.conference.id,
+                title: n.conference.title,
+                description: n.conference.description,
+                created_at: n.conference.created_at,
+                deadline: n.conference.deadline,
+                roles: n.conference.roles,
+            },
+            status: n.status,
+            }));
+
+            currentPage = data.current_page;
+            totalPages = data.total_pages;
+
+        } catch (error) {
+            console.error('Errore:', error);
+        }
+    }
+
+  
+    async function handleNotificationAction(notificationId: number, status: 'accept' | 'reject') {
+      try {
+        // Effettua la chiamata al backend
+        const response = await fetch(`/notifications/update-notification/`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            id_notification: notificationId,
+            status,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Errore nella risposta del server: ${response.statusText}`);
+        }
+
+        // Aggiorna lo stato della notifica localmente
+        notifications = notifications.map((n) =>
+          n.id === notificationId ? { ...n, status: status === 'accept' ? 'accept' : 'reject' } : n
+        );
+      } catch (error) {
+        console.error(`Errore durante l'aggiornamento della notifica (${status}):`, error);
+        alert('Errore: impossibile aggiornare la notifica.');
+      }
+    }
+
+  
+    onMount(() => {
+      fetchNotifications(currentPage);
+    });
+  
+    function goToPage(page: number) {
+      if (page >= 1 && page <= totalPages) {
+        fetchNotifications(page);
+      }
+    }
+  </script>
+  
+<div class="container mx-auto p-4">
+  <h1 class="text-2xl font-bold mb-6">Notifications</h1>
+
+  <!-- Tabella notifiche -->
+  <div class="overflow-x-auto" transition:fade>
+    <table class="table table-zebra w-full">
+      <thead>
+        <tr>
+          <th>Sender</th>
+          <th>Conference</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+          {#each notifications as notification (notification.id)}
+          <tr>
+            <td>{notification.sender}</td>
+            <td>
+              <span class="font-semibold">{notification.conference.title}</span>
+              <br />
+              <span class="text-sm text-gray-500">
+                Deadline: {new Date(notification.conference.deadline).toLocaleDateString('it-IT')}
+              </span>
+            </td>
+            <td class="flex gap-2">
+              {#if notification.status === 'pending'}
+              <button
+                class="btn btn-success btn-sm"
+                on:click={() => handleNotificationAction(notification.id, 'accept')}
+              >
+                Accept
+              </button>
+              <button
+                class="btn btn-error btn-sm"
+                on:click={() => handleNotificationAction(notification.id, 'reject')}
+              >
+                Decline
+              </button>
+              {:else}
+                <span class="text-gray-500">{notification.status === 'accept' ? 'Accepted' : 'Declined'}</span>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Paginazione -->
+  <div class="flex justify-center mt-6">
+    <div class="join">
+      <!-- Prima pagina -->
+      {#if currentPage > 2}
+        <button class="join-item btn" on:click={() => goToPage(1)}>1</button>
+      {/if}
+
+      <!-- Ellissi prima -->
+      {#if currentPage > 3}
+        <button class="join-item btn btn-disabled">...</button>
+      {/if}
+
+      <!-- Pagina precedente -->
+      {#if currentPage > 1}
+        <button class="join-item btn" on:click={() => goToPage(currentPage - 1)}>
+          {currentPage - 1}
+        </button>
+      {/if}
+
+      <!-- Pagina corrente -->
+      <button class="join-item btn btn-active">{currentPage}</button>
+
+      <!-- Pagina successiva -->
+      {#if currentPage < totalPages}
+        <button class="join-item btn" on:click={() => goToPage(currentPage + 1)}>
+          {currentPage + 1}
+        </button>
+      {/if}
+
+      <!-- Ellissi dopo -->
+      {#if currentPage < totalPages - 2}
+        <button class="join-item btn btn-disabled">...</button>
+      {/if}
+
+      <!-- Ultima pagina -->
+      {#if totalPages > 1 && currentPage < totalPages - 1}
+        <button class="join-item btn" on:click={() => goToPage(totalPages)}>
+          {totalPages}
+        </button>
+      {/if}
+    </div>
+  </div>
+</div>  

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -3,206 +3,208 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import { vi } from 'vitest';
 
 describe('Notifications Page', () => {
+    const mockFetch = vi.fn();
+
     beforeEach(() => {
-        // Mock globale di fetch
-        global.fetch = vi.fn();
-        });
+        vi.stubGlobal('fetch', mockFetch);
+    });
         
     afterEach(() => {
-    vi.restoreAllMocks();
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    test('renders notifications table and pagination', async () => {
+        // Mock della risposta API per fetchNotifications
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                notifications: [
+                    {
+                        id: 1,
+                        sender: 'User1',
+                        conference: {
+                            id: 101,
+                            title: 'Conference 101',
+                            description: 'Description',
+                            created_at: '2024-11-10T12:00:00Z',
+                            deadline: '2024-12-01T12:00:00Z',
+                            roles: ['admin'],
+                        },
+                        status: 'pending',
+                    },
+                ],
+                current_page: 1,
+                total_pages: 3,
+            }),
         });
 
-  test('renders notifications table and pagination', async () => {
-    // Mock della risposta API per fetchNotifications
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        notifications: [
-          {
-            id: 1,
-            sender: 'User1',
-            conference: {
-              id: 101,
-              title: 'Conference 101',
-              description: 'Description',
-              created_at: '2024-11-10T12:00:00Z',
-              deadline: '2024-12-01T12:00:00Z',
-              roles: ['admin'],
-            },
-            status: 'pending',
-          },
-        ],
-        current_page: 1,
-        total_pages: 3,
-      }),
+        render(NotificationsPage);
+
+        // Attendi che la tabella venga popolata
+        expect(await screen.findByText('User1')).toBeInTheDocument();
+        expect(screen.getByText('Conference 101')).toBeInTheDocument();
+        expect(screen.getByText('Deadline: 01/12/2024')).toBeInTheDocument();
+
+        // Controlla elementi di paginazione
+        expect(screen.getByText('1')).toBeInTheDocument();
+        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText('3')).toBeInTheDocument();
     });
 
-    render(NotificationsPage);
+    test('handles Accept action correctly', async () => {
+        // Mock della risposta API
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                notifications: [
+                    {
+                        id: 1,
+                        sender: 'User1',
+                        conference: {
+                            id: 101,
+                            title: 'Conference 101',
+                            description: 'Description',
+                            created_at: '2024-11-10T12:00:00Z',
+                            deadline: '2024-12-01T12:00:00Z',
+                            roles: ['admin'],
+                        },
+                        status: 'pending',
+                    },
+                ],
+                current_page: 1,
+                total_pages: 3,
+            }),
+        });
 
-    // Attendi che la tabella venga popolata
-    expect(await screen.findByText('User1')).toBeInTheDocument();
-    expect(screen.getByText('Conference 101')).toBeInTheDocument();
-    expect(screen.getByText('Deadline: 01/12/2024')).toBeInTheDocument();
+        // Mock della chiamata PATCH
+        mockFetch.mockResolvedValueOnce({ ok: true });
 
-    // Controlla elementi di paginazione
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
-  });
+        render(NotificationsPage);
 
-  test('handles Accept action correctly', async () => {
-    // Mock della risposta API
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        notifications: [
-          {
-            id: 1,
-            sender: 'User1',
-            conference: {
-              id: 101,
-              title: 'Conference 101',
-              description: 'Description',
-              created_at: '2024-11-10T12:00:00Z',
-              deadline: '2024-12-01T12:00:00Z',
-              roles: ['admin'],
-            },
-            status: 'pending',
-          },
-        ],
-        current_page: 1,
-        total_pages: 3,
-      }),
+        // Attendi che i dati vengano renderizzati
+        const acceptButton = await screen.findByText('Accept');
+        await fireEvent.click(acceptButton);
+
+        // Controlla la chiamata a fetch
+        expect(mockFetch).toHaveBeenCalledWith(
+            '/notifications/update-notification/',
+            expect.objectContaining({
+                method: 'PATCH',
+                body: JSON.stringify({ id_notification: 1, status: 'accept' }),
+            })
+        );
+
+        // Verifica che lo stato venga aggiornato localmente
+        expect(screen.queryByText('Accept')).not.toBeInTheDocument();
+        expect(screen.getByText('Accepted')).toBeInTheDocument();
     });
 
-    // Mock della chiamata PATCH
-    fetch.mockResolvedValueOnce({ ok: true });
+    test('handles Decline action correctly', async () => {
+        // Mock della risposta API
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                notifications: [
+                    {
+                        id: 1,
+                        sender: 'User1',
+                        conference: {
+                            id: 101,
+                            title: 'Conference 101',
+                            description: 'Description',
+                            created_at: '2024-11-10T12:00:00Z',
+                            deadline: '2024-12-01T12:00:00Z',
+                            roles: ['admin'],
+                        },
+                        status: 'pending',
+                    },
+                ],
+                current_page: 1,
+                total_pages: 3,
+            }),
+        });
 
-    render(NotificationsPage);
+        // Mock della chiamata PATCH
+        mockFetch.mockResolvedValueOnce({ ok: true });
 
-    // Attendi che i dati vengano renderizzati
-    const acceptButton = await screen.findByText('Accept');
-    await fireEvent.click(acceptButton);
+        render(NotificationsPage);
 
-    // Controlla la chiamata a fetch
-    expect(fetch).toHaveBeenCalledWith(
-      '/notifications/update-notification/',
-      expect.objectContaining({
-        method: 'PATCH',
-        body: JSON.stringify({ id_notification: 1, status: 'accept' }),
-      })
-    );
+        // Attendi che i dati vengano renderizzati
+        const declineButton = await screen.findByText('Decline');
+        await fireEvent.click(declineButton);
 
-    // Verifica che lo stato venga aggiornato localmente
-    expect(screen.queryByText('Accept')).not.toBeInTheDocument();
-    expect(screen.getByText('Accepted')).toBeInTheDocument();
-  });
+        // Controlla la chiamata a fetch
+        expect(mockFetch).toHaveBeenCalledWith(
+            '/notifications/update-notification/',
+            expect.objectContaining({
+                method: 'PATCH',
+                body: JSON.stringify({ id_notification: 1, status: 'reject' }),
+            })
+        );
 
-  test('handles Decline action correctly', async () => {
-    // Mock della risposta API
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        notifications: [
-          {
-            id: 1,
-            sender: 'User1',
-            conference: {
-              id: 101,
-              title: 'Conference 101',
-              description: 'Description',
-              created_at: '2024-11-10T12:00:00Z',
-              deadline: '2024-12-01T12:00:00Z',
-              roles: ['admin'],
-            },
-            status: 'pending',
-          },
-        ],
-        current_page: 1,
-        total_pages: 3,
-      }),
+        // Verifica che lo stato venga aggiornato localmente
+        expect(screen.queryByText('Decline')).not.toBeInTheDocument();
+        expect(screen.getByText('Declined')).toBeInTheDocument();
     });
 
-    // Mock della chiamata PATCH
-    fetch.mockResolvedValueOnce({ ok: true });
+    test('navigates to another page using pagination', async () => {
+        // Mock della prima pagina
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                notifications: [
+                    {
+                        id: 1,
+                        sender: 'User1',
+                        conference: {
+                            id: 101,
+                            title: 'Conference 101',
+                            description: 'Description',
+                            created_at: '2024-11-10T12:00:00Z',
+                            deadline: '2024-12-01T12:00:00Z',
+                            roles: ['admin'],
+                        },
+                        status: 'pending',
+                    },
+                ],
+                current_page: 1,
+                total_pages: 3,
+            }),
+        });
 
-    render(NotificationsPage);
+        // Mock della seconda pagina
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                notifications: [
+                    {
+                        id: 11,
+                        sender: 'User2',
+                        conference: {
+                            id: 201,
+                            title: 'Conference 201',
+                            description: 'Description 201',
+                            created_at: '2024-11-10T12:00:00Z',
+                            deadline: '2024-12-02T12:00:00Z',
+                            roles: ['reviewer'],
+                        },
+                        status: 'pending',
+                    },
+                ],
+                current_page: 2,
+                total_pages: 3,
+            }),
+        });
 
-    // Attendi che i dati vengano renderizzati
-    const declineButton = await screen.findByText('Decline');
-    await fireEvent.click(declineButton);
+        render(NotificationsPage);
 
-    // Controlla la chiamata a fetch
-    expect(fetch).toHaveBeenCalledWith(
-      '/notifications/update-notification/',
-      expect.objectContaining({
-        method: 'PATCH',
-        body: JSON.stringify({ id_notification: 1, status: 'reject' }),
-      })
-    );
+        // Vai alla pagina 2
+        const nextPageButton = await screen.findByText('2');
+        await fireEvent.click(nextPageButton);
 
-    // Verifica che lo stato venga aggiornato localmente
-    expect(screen.queryByText('Decline')).not.toBeInTheDocument();
-    expect(screen.getByText('Declined')).toBeInTheDocument();
-  });
-
-  test('navigates to another page using pagination', async () => {
-    // Mock della prima pagina
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        notifications: [
-          {
-            id: 1,
-            sender: 'User1',
-            conference: {
-              id: 101,
-              title: 'Conference 101',
-              description: 'Description',
-              created_at: '2024-11-10T12:00:00Z',
-              deadline: '2024-12-01T12:00:00Z',
-              roles: ['admin'],
-            },
-            status: 'pending',
-          },
-        ],
-        current_page: 1,
-        total_pages: 3,
-      }),
+        // Verifica che la nuova pagina venga caricata
+        expect(await screen.findByText('User2')).toBeInTheDocument();
+        expect(screen.getByText('Conference 201')).toBeInTheDocument();
     });
-
-    // Mock della seconda pagina
-    fetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        notifications: [
-          {
-            id: 11,
-            sender: 'User2',
-            conference: {
-              id: 201,
-              title: 'Conference 201',
-              description: 'Description 201',
-              created_at: '2024-11-10T12:00:00Z',
-              deadline: '2024-12-02T12:00:00Z',
-              roles: ['reviewer'],
-            },
-            status: 'pending',
-          },
-        ],
-        current_page: 2,
-        total_pages: 3,
-      }),
-    });
-
-    render(NotificationsPage);
-
-    // Vai alla pagina 2
-    const nextPageButton = await screen.findByText('2');
-    await fireEvent.click(nextPageButton);
-
-    // Verifica che la nuova pagina venga caricata
-    expect(await screen.findByText('User2')).toBeInTheDocument();
-    expect(screen.getByText('Conference 201')).toBeInTheDocument();
-  });
 });

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,208 @@
+import NotificationsPage from '../src/routes/notifications/+page.svelte';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { vi } from 'vitest';
+
+describe('Notifications Page', () => {
+    beforeEach(() => {
+        // Mock globale di fetch
+        global.fetch = vi.fn();
+        });
+        
+    afterEach(() => {
+    vi.restoreAllMocks();
+        });
+
+  test('renders notifications table and pagination', async () => {
+    // Mock della risposta API per fetchNotifications
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        notifications: [
+          {
+            id: 1,
+            sender: 'User1',
+            conference: {
+              id: 101,
+              title: 'Conference 101',
+              description: 'Description',
+              created_at: '2024-11-10T12:00:00Z',
+              deadline: '2024-12-01T12:00:00Z',
+              roles: ['admin'],
+            },
+            status: 'pending',
+          },
+        ],
+        current_page: 1,
+        total_pages: 3,
+      }),
+    });
+
+    render(NotificationsPage);
+
+    // Attendi che la tabella venga popolata
+    expect(await screen.findByText('User1')).toBeInTheDocument();
+    expect(screen.getByText('Conference 101')).toBeInTheDocument();
+    expect(screen.getByText('Deadline: 01/12/2024')).toBeInTheDocument();
+
+    // Controlla elementi di paginazione
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  test('handles Accept action correctly', async () => {
+    // Mock della risposta API
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        notifications: [
+          {
+            id: 1,
+            sender: 'User1',
+            conference: {
+              id: 101,
+              title: 'Conference 101',
+              description: 'Description',
+              created_at: '2024-11-10T12:00:00Z',
+              deadline: '2024-12-01T12:00:00Z',
+              roles: ['admin'],
+            },
+            status: 'pending',
+          },
+        ],
+        current_page: 1,
+        total_pages: 3,
+      }),
+    });
+
+    // Mock della chiamata PATCH
+    fetch.mockResolvedValueOnce({ ok: true });
+
+    render(NotificationsPage);
+
+    // Attendi che i dati vengano renderizzati
+    const acceptButton = await screen.findByText('Accept');
+    await fireEvent.click(acceptButton);
+
+    // Controlla la chiamata a fetch
+    expect(fetch).toHaveBeenCalledWith(
+      '/notifications/update-notification/',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ id_notification: 1, status: 'accept' }),
+      })
+    );
+
+    // Verifica che lo stato venga aggiornato localmente
+    expect(screen.queryByText('Accept')).not.toBeInTheDocument();
+    expect(screen.getByText('Accepted')).toBeInTheDocument();
+  });
+
+  test('handles Decline action correctly', async () => {
+    // Mock della risposta API
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        notifications: [
+          {
+            id: 1,
+            sender: 'User1',
+            conference: {
+              id: 101,
+              title: 'Conference 101',
+              description: 'Description',
+              created_at: '2024-11-10T12:00:00Z',
+              deadline: '2024-12-01T12:00:00Z',
+              roles: ['admin'],
+            },
+            status: 'pending',
+          },
+        ],
+        current_page: 1,
+        total_pages: 3,
+      }),
+    });
+
+    // Mock della chiamata PATCH
+    fetch.mockResolvedValueOnce({ ok: true });
+
+    render(NotificationsPage);
+
+    // Attendi che i dati vengano renderizzati
+    const declineButton = await screen.findByText('Decline');
+    await fireEvent.click(declineButton);
+
+    // Controlla la chiamata a fetch
+    expect(fetch).toHaveBeenCalledWith(
+      '/notifications/update-notification/',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ id_notification: 1, status: 'reject' }),
+      })
+    );
+
+    // Verifica che lo stato venga aggiornato localmente
+    expect(screen.queryByText('Decline')).not.toBeInTheDocument();
+    expect(screen.getByText('Declined')).toBeInTheDocument();
+  });
+
+  test('navigates to another page using pagination', async () => {
+    // Mock della prima pagina
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        notifications: [
+          {
+            id: 1,
+            sender: 'User1',
+            conference: {
+              id: 101,
+              title: 'Conference 101',
+              description: 'Description',
+              created_at: '2024-11-10T12:00:00Z',
+              deadline: '2024-12-01T12:00:00Z',
+              roles: ['admin'],
+            },
+            status: 'pending',
+          },
+        ],
+        current_page: 1,
+        total_pages: 3,
+      }),
+    });
+
+    // Mock della seconda pagina
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        notifications: [
+          {
+            id: 11,
+            sender: 'User2',
+            conference: {
+              id: 201,
+              title: 'Conference 201',
+              description: 'Description 201',
+              created_at: '2024-11-10T12:00:00Z',
+              deadline: '2024-12-02T12:00:00Z',
+              roles: ['reviewer'],
+            },
+            status: 'pending',
+          },
+        ],
+        current_page: 2,
+        total_pages: 3,
+      }),
+    });
+
+    render(NotificationsPage);
+
+    // Vai alla pagina 2
+    const nextPageButton = await screen.findByText('2');
+    await fireEvent.click(nextPageButton);
+
+    // Verifica che la nuova pagina venga caricata
+    expect(await screen.findByText('User2')).toBeInTheDocument();
+    expect(screen.getByText('Conference 201')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
added Notifications page with accept/reject call. This covers SIP-58 as well. The page is tested but I dont have 100% certainty the calls are made correctly considering the back isn't ready yet. A fix in the fetch and answer calls will take a couple minutes to be implemented so I'm marking this as completed